### PR TITLE
illuminate/contracts ^9.0 to  ^10.33.0  for laravel v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^10.33.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
- Change composer.json file for laravel v10 
- Change illuminate/contracts ^9.0 version to latest [^10.33.0]